### PR TITLE
Strip-option removes *all* leading and trailing white-space.

### DIFF
--- a/step/step.py
+++ b/step/step.py
@@ -7,7 +7,7 @@ class Template(object):
 
     COMPILED_TEMPLATES = {} # {template string: code object, }
     # Regex for stripping all leading, trailing and interleaving whitespace.
-    RE_STRIP = re.compile("(^[ \t]+|[ \t]+$|(?<=[ \t])[ \t]+|^\r?\n)", re.M)
+    RE_STRIP = re.compile("(^[ \t]+|[ \t]+$|(?<=[ \t])[ \t]+|\A[\r\n]+|[ \t\r\n]+\Z)", re.M)
 
     def __init__(self, template, strip=True):
         """Initialize class"""

--- a/step/tests/test_template.py
+++ b/step/tests/test_template.py
@@ -27,8 +27,8 @@ class TestTemplate(unittest.TestCase):
                   {{eggs}} eggs
                %endif"""
         values = {"eggs": 3}
-        output = "I have 3 eggs\n"
-        self.assertEqual(step.Template(tmpl, strip=True).expand(values), output)
+        output = "I have 3 eggs"
+        self.assertEqual(step.Template(tmpl).expand(values), output)
 
     def test_isdef(self):
         tmpl = r"""
@@ -37,7 +37,7 @@ class TestTemplate(unittest.TestCase):
                %else:
                    I don't like spam
                %endif"""
-        output = "I don't like spam\n"
+        output = "I don't like spam"
         self.assertEqual(step.Template(tmpl).expand({}), output)
 
     def test_echo(self):
@@ -47,4 +47,11 @@ class TestTemplate(unittest.TestCase):
                %>"""
         values = {"eggs": 1}
         output = "I have 1 egg"
+        self.assertEqual(step.Template(tmpl).expand(values), output)
+
+
+    def test_strip(self):
+        tmpl = "\n\nName:\t\t\t{{var}}\n \t\n"
+        values = {"var": 1}
+        output = "Name:\t1"
         self.assertEqual(step.Template(tmpl).expand(values), output)


### PR DESCRIPTION
I made another change you might want to merge back: the strip function did not remove the very final trailing whitespace. For example "some string\n\n" would be stripped to "some string\n". This change would strip it to "some string".

At least, this made sense in my usage, as I'm also producing TXT output, where trailing newlines make a difference.
