### PR TITLE
Support for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Python code.
 
 Installation
 ------------
-Download the package from [GitHub](https://github.com/dotpy/step/) and run the
+Use pip:
+
+    # pip install step-template
+
+or download the package from [GitHub](https://github.com/dotpy/step/) and run the
 install script:
 
     # python setup.py install

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To run the test suite, just run `python setup.py test`.
 
 Credits
 -------
-Copyright (c) 2012-2013 Daniele Mazzocchio (danix@kernel-panic.it).
+Copyright (c) 2012 Daniele Mazzocchio (danix@kernel-panic.it).
 Several improvements by Erki Suurjaak.
 
-Licensed under BSD license (see LICENSE.md file).
+Licensed under the BSD license (see [LICENSE.md](LICENSE.md) file).

--- a/setup.py
+++ b/setup.py
@@ -28,18 +28,25 @@ if sys.version < "2.2.3":
     DistributionMetadata.classifiers = None
     DistributionMetadata.download_url = None
 
-setup(name         = "step",
+setup(name         = "step-template",
       version      = __version__,
       author       = "Daniele Mazzocchio",
       author_email = "danix@kernel-panic.it",
-      packages     = ["step"],
+      packages     = ["step", "step.tests"],
       cmdclass     = {"test": TestCommand},
       description  = "Simple Template Engine for Python",
-      classifiers  = ["Development status :: 2 - Pre-Alpha",
+      classifiers  = ["Development Status :: 5 - Production/Stable",
                       "Environment :: Console",
                       "Intended Audience :: Developers",
-                      "License :: Other/Proprietary License",
+                      "License :: OSI Approved :: BSD License",
                       "Natural Language :: English",
                       "Operating System :: OS Independent",
                       "Programming Language :: Python",
-                      "Topic :: Text Processing"])
+                      "Topic :: Text Processing"],
+      url="https://github.com/dotpy/step",
+      license="BSD",
+      keywords="templates templating template-engines",
+      long_description="step is a pure-Python module providing a very "
+      "simple template engine with minimum syntax. It supports variable "
+      "expansion, flow control and embedding of Python code.",
+)


### PR DESCRIPTION
If you're interested, here is support for step to be pip-installable. You would need to create an account on pypi.python.org, create a suitable .pypirc file in your home directory, and execute this:

    python setup.py register -r pypi
    python setup.py sdist upload -r pypi

I tested it on testpypi.python.org, everything worked well. [This](http://peterdowns.com/posts/first-time-with-pypi.html) is a good short guide on how to submit to PyPI.

As "step" is already taken on PyPI, I used "step-template" for the package name instead.
I also updated a few texts, if that's okay.
